### PR TITLE
docs: restore 6 dead link(s) via Wayback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 Zenbot is a command-line cryptocurrency trading bot using Node.js and MongoDB. It features:
 
-- Fully-automated [technical-analysis](https://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:introduction_to_technical_indicators_and_oscillators)-based trading approach
-- Full support for [Binance](https://www.binance.com/), [Bitfinex](https://www.bitfinex.com/), [Bitstamp](https://www.bitstamp.net/), [Bittrex](https://bittrex.com/), [CEX.IO](https://cex.io/), [GDAX](https://gdax.com/), [Gemini](https://gemini.com/), [HitBTC](https://hitbtc.com/), [Kraken](https://www.kraken.com/), [Poloniex](https://poloniex.com/), [QuadrigaCX](https://www.quadrigacx.com/) and [TheRockTrading](https://www.therocktrading.com/), work on further exchange support is ongoing.
+- Fully-automated [technical-analysis](http://web.archive.org/web/20190201183443/http://stockcharts.com:80/school/doku.php?id=chart_school:technical_indicators:introduction_to_technical_indicators_and_oscillators)-based trading approach
+- Full support for [Binance](https://www.binance.com/), [Bitfinex](https://www.bitfinex.com/), [Bitstamp](https://www.bitstamp.net/), [Bittrex](https://bittrex.com/), [CEX.IO](https://cex.io/), [GDAX](http://web.archive.org/web/20180623120241/https://www.gdax.com/), [Gemini](https://gemini.com/), [HitBTC](https://hitbtc.com/), [Kraken](https://www.kraken.com/), [Poloniex](https://poloniex.com/), [QuadrigaCX](http://web.archive.org/web/20260519182208/http://www.quadrigacx.com/) and [TheRockTrading](https://www.therocktrading.com/), work on further exchange support is ongoing.
 - Plugin architecture for implementing exchange support, or writing new strategies
 - Simulator for [backtesting strategies](https://gist.github.com/carlos8f/b09a734cf626ffb9bb3bcb1ca35f3db4) against historical data
 - "Paper" trading mode, operates on a simulated balance while watching the live market

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ npm link
 
 ### Ubuntu 16.04 Step-By-Step
 [Video](https://youtu.be/BEhU55W9pBI)
-[Blog Post](https://jaynagpaul.com/algorithmic-crypto-trading?utm_source=zenbot)
+[Blog Post](http://web.archive.org/web/20191212212602/https://jaynagpaul.com/algorithmic-crypto-trading?utm_source=zenbot)
 
 ```
 sudo apt-get update
@@ -162,7 +162,7 @@ zenbot list-strategies
 
 ### Screenshot and example result
 
-Zenbot outputs an HTML graph of each simulation result. In the screenshot below, the pink arrows represent the bot buying (up arrow) and selling (down arrow) as it iterated the historical data of [GDAX](https://gdax.com/) exchange's BTC/USD product.
+Zenbot outputs an HTML graph of each simulation result. In the screenshot below, the pink arrows represent the bot buying (up arrow) and selling (down arrow) as it iterated the historical data of [GDAX](http://web.archive.org/web/20180623120241/https://www.gdax.com/) exchange's BTC/USD product.
 
 ![screenshot](https://cloud.githubusercontent.com/assets/106763/25983930/7e5f9436-369c-11e7-971b-ba2916442eea.png)
 
@@ -619,7 +619,7 @@ From left to right:
 - Asset price in currency (yellow)
 - Percent change of price since last period (red/green)
 - Volume in asset since last period (grey)
-- [RSI](http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:relative_strength_index_rsi) ANSI graph (red/green)
+- [RSI](http://web.archive.org/web/20190504143936/http://stockcharts.com:80/school/doku.php?id=chart_school:technical_indicators:relative_strength_index_rsi) ANSI graph (red/green)
 - `trend_ema_rate` (red/green, explained below)
 - Current signal or action, including `buy`, `sell`, `buying`, `selling`, `bought`, `sold` and `last_trade_worth` (percent change in the trend direction since last buy/sell)
 - Account balance (asset)


### PR DESCRIPTION
This PR fixes 6 broken outbound documentation link(s).

Changes:
- `README.md`: `https://stockcharts.com/school/doku.php?id=chart_school:technical_indi` → `http://web.archive.org/web/20190201183443/http://stockcharts.com:80/sc` (Wayback snapshot (host dead))
- `README.md`: `https://gdax.com/` → `http://web.archive.org/web/20180623120241/https://www.gdax.com/` (Wayback snapshot (host dead))
- `README.md`: `https://www.quadrigacx.com/` → `http://web.archive.org/web/20260519182208/http://www.quadrigacx.com/` (Wayback snapshot (host dead))
- `docs/README.md`: `https://jaynagpaul.com/algorithmic-crypto-trading?utm_source=zenbot` → `http://web.archive.org/web/20191212212602/https://jaynagpaul.com/algor` (Wayback snapshot (host dead))
- `docs/README.md`: `https://gdax.com/` → `http://web.archive.org/web/20180623120241/https://www.gdax.com/` (Wayback snapshot (host dead))
- `docs/README.md`: `http://stockcharts.com/school/doku.php?id=chart_school:technical_indic` → `http://web.archive.org/web/20190504143936/http://stockcharts.com:80/sc` (Wayback snapshot (host dead))

Fixes #940